### PR TITLE
only fetch apk cache once

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.6 as alpine
-RUN apk add -U --no-cache ca-certificates mailcap
+RUN apk add --no-cache ca-certificates mailcap
 
 FROM scratch
 MAINTAINER Drone.IO Community <drone-dev@googlegroups.com>


### PR DESCRIPTION
The `-U` flag fetches the apk cache and stores it in /var/cache/apk.  The `--no-cache` flag fetches the apk cache, but doesn't store it.  Using both flags results in the apk cache being fetched twice.

In this output you can see the main and community apk indexes are fetched twice each.
```
$ docker run -it --rm alpine:3.6
/ # apk add -U --no-cache ca-certificates mailcap
fetch http://dl-cdn.alpinelinux.org/alpine/v3.6/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.6/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.6/community/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.6/community/x86_64/APKINDEX.tar.gz
(1/2) Installing ca-certificates (20161130-r2)
(2/2) Installing mailcap (2.1.47-r0)
Executing busybox-1.26.2-r7.trigger
Executing ca-certificates-20161130-r2.trigger
OK: 5 MiB in 13 packages
```

Removing the `-U` flag causes them to be fetched once each.
```
$ docker run -it --rm alpine:3.6
/ # apk add --no-cache ca-certificates mailcap
fetch http://dl-cdn.alpinelinux.org/alpine/v3.6/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.6/community/x86_64/APKINDEX.tar.gz
(1/2) Installing ca-certificates (20161130-r2)
(2/2) Installing mailcap (2.1.47-r0)
Executing busybox-1.26.2-r7.trigger
Executing ca-certificates-20161130-r2.trigger
OK: 5 MiB in 13 packages
```