### PR TITLE
Remove deprecated MANTAINER from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ FROM alpine:3.6 as alpine
 RUN apk add --no-cache ca-certificates mailcap
 
 FROM scratch
-MAINTAINER Drone.IO Community <drone-dev@googlegroups.com>
 
 ENV GODEBUG=netdns=go
 
@@ -14,3 +13,4 @@ LABEL org.label-schema.vcs-url="https://github.com/drone-plugins/drone-base.git"
 LABEL org.label-schema.name="Drone Base"
 LABEL org.label-schema.vendor="Drone.IO Community"
 LABEL org.label-schema.schema-version="1.0"
+LABEL org.label-schema.maintainer="Drone.IO Community <drone-dev@googlegroups.com>"

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,7 @@ ENV GODEBUG=netdns=go
 COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=alpine /etc/mime.types /etc/
 
-LABEL org.label-schema.version=multiarch
-LABEL org.label-schema.vcs-url="https://github.com/drone-plugins/drone-base.git"
-LABEL org.label-schema.name="Drone Base"
-LABEL org.label-schema.vendor="Drone.IO Community"
-LABEL org.label-schema.schema-version="1.0"
-LABEL org.label-schema.maintainer="Drone.IO Community <drone-dev@googlegroups.com>"
+LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" \
+  org.label-schema.name="Drone Base" \
+  org.label-schema.vendor="Drone.IO Community" \
+  org.label-schema.schema-version="1.0"


### PR DESCRIPTION
As reported in changelog docker 1.13 deprecate `MAINTAINER` entry in `Dockerfile` that should be replaced with an appropriate label. More info here https://docs.docker.com/engine/deprecated/

<!-- PLEASE READ BEFORE DELETING

Please discuss changes before creating pull requests.

    https://gitter.im/drone/drone

-->
