### PR TITLE
Use microsoft/powershell as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,13 @@
 # escape=`
-FROM microsoft/nanoserver:10.0.14393.1593
+# The nanoserver:1709 container does not come with powershell installed on it
+# so the powershell image should be used when requiring any commands to be run
+# to add to the image contents
+FROM microsoft/powershell:nanoserver
 
 LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" `
   org.label-schema.name="Drone Base" `
   org.label-schema.vendor="Drone.IO Community" `
   org.label-schema.schema-version="1.0"
 
-SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+# In the powershell container pwsh is the name of the command
+SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]


### PR DESCRIPTION
The 1709 nanoserver image does not contain powershell so use microsoft/powershell:nanoserver instead

