### PR TITLE
Add windows support

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -1,143 +1,54 @@
-local PipelineBuild(os="linux", arch="amd64") = {
-  kind: "pipeline",
-  name: os + "-" + arch,
-  platform: {
-    os: os,
-    arch: arch,
-  },
-  steps: [
-    {
-      name: "dryrun",
-      image: "plugins/docker:" + os + "-" + arch,
-      pull: "always",
-      settings: {
-        dry_run: true,
-        tags: os + "-" + arch,
-        dockerfile: "docker/Dockerfile." + os + "." + arch,
-        repo: "plugins/base",
-        username: { "from_secret": "docker_username" },
-        password: { "from_secret": "docker_password" },
-      },
-      when: {
-        event: [ "pull_request" ],
-      },
-    },
-    {
-      name: "publish",
-      image: "plugins/docker:" + os + "-" + arch,
-      pull: "always",
-      settings: {
-        auto_tag: true,
-        auto_tag_suffix: os + "-" + arch,
-        dockerfile: "docker/Dockerfile." + os + "." + arch,
-        repo: "plugins/base",
-        username: { "from_secret": "docker_username" },
-        password: { "from_secret": "docker_password" },
-      },
-      when: {
-        event: [ "push" ],
-      },
-    },
-  ],
-  trigger: {
-    branch: [ "master" ],
-  },
-};
+local pipeline = import 'pipeline.libsonnet';
 
 local PipelineMultiarch = {
-  kind: "pipeline",
-  name: "linux-multiarch",
+  kind: 'pipeline',
+  name: 'linux-multiarch',
   platform: {
-    os: "linux",
-    arch: "amd64",
+    os: 'linux',
+    arch: 'amd64',
   },
   steps: [
     {
-      name: "dryrun",
-      image: "plugins/docker:linux-amd64",
-      pull: "always",
+      name: 'dryrun',
+      image: 'plugins/docker:linux-amd64',
+      pull: 'always',
       settings: {
         dry_run: true,
-        tags: [ "multiarch" ],
-        dockerfile: "docker/Dockerfile.linux.multiarch",
-        repo: "plugins/base",
-        username: { "from_secret": "docker_username" },
-        password: { "from_secret": "docker_password" },
+        tags: ['multiarch'],
+        dockerfile: 'docker/Dockerfile.linux.multiarch',
+        repo: 'plugins/base',
+        username: { from_secret: 'docker_username' },
+        password: { from_secret: 'docker_password' },
       },
       when: {
-        event: [ "pull_request" ],
+        event: ['pull_request'],
       },
     },
     {
-      name: "publish",
-      image: "plugins/docker:linux-amd64",
-      pull: "always",
+      name: 'publish',
+      image: 'plugins/docker:linux-amd64',
+      pull: 'always',
       settings: {
-        tags: [ "multiarch" ],
-        dockerfile: "docker/Dockerfile.linux.multiarch",
-        repo: "plugins/base",
-        username: { "from_secret": "docker_username" },
-        password: { "from_secret": "docker_password" },
+        tags: ['multiarch'],
+        dockerfile: 'docker/Dockerfile.linux.multiarch',
+        repo: 'plugins/base',
+        username: { from_secret: 'docker_username' },
+        password: { from_secret: 'docker_password' },
       },
       when: {
-        event: [ "push" ],
+        event: ['push'],
       },
     },
   ],
   trigger: {
-    branch: [ "master" ],
-  },
-};
-
-local PipelineNotifications = {
-  kind: "pipeline",
-  name: "notifications",
-  platform: {
-    os: "linux",
-    arch: "amd64",
-  },
-  steps: [
-    {
-      name: "manifest",
-      image: "plugins/manifest:1",
-      pull: "always",
-      settings: {
-        username: { "from_secret": "docker_username" },
-        password: { "from_secret": "docker_password" },
-        spec: "docker/manifest.tmpl",
-        ignore_missing: true,
-      },
-      when: {
-        event: [ "push" ]
-      }
-    },
-    {
-      name: "microbadger",
-      image: "plugins/webhook:1",
-      pull: "always",
-      settings: {
-        url: { "from_secret": "microbadger_url" },
-      },
-      when: {
-        event: [ "push" ]
-      }
-    },
-  ],
-  depends_on: [
-    "linux-amd64",
-    "linux-arm64",
-    "linux-arm",
-    "linux-multiarch",
-  ],
-  trigger: {
-    branch: [ "master" ],
+    branch: ['master'],
   },
 };
 
 [
-    PipelineBuild("linux", "amd64"),
-    PipelineBuild("linux", "arm64"),
-    PipelineBuild("linux", "arm"),
-    PipelineMultiarch,
-    PipelineNotifications,
+  pipeline.build('linux', 'amd64'),
+  pipeline.build('linux', 'arm64'),
+  pipeline.build('linux', 'arm'),
+  PipelineMultiarch,
+  pipeline.notifications(),
 ]

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -50,5 +50,10 @@ local PipelineMultiarch = {
   pipeline.build('linux', 'arm64'),
   pipeline.build('linux', 'arm'),
   PipelineMultiarch,
-  pipeline.notifications(),
+  pipeline.notifications(depends_on=[
+    'linux-amd64',
+    'linux-arm64',
+    'linux-arm',
+    'linux-multiarch',
+  ]),
 ]

--- a/.drone.windows.jsonnet
+++ b/.drone.windows.jsonnet
@@ -1,0 +1,7 @@
+local pipeline = import 'pipeline.libsonnet';
+
+[
+  pipeline.build('windows', 'amd64', '1803'),
+  pipeline.build('windows', 'amd64', '1809'),
+  pipeline.notifications('windows', 'amd64', '1809', ['windows-1803', 'windows-1809']),
+]

--- a/.drone.windows.yml
+++ b/.drone.windows.yml
@@ -1,5 +1,62 @@
 ---
 kind: pipeline
+name: windows-1803
+
+platform:
+  os: windows
+  arch: amd64
+  version: 1803
+
+steps:
+- name: dryrun
+  pull: always
+  image: plugins/docker:windows-1803
+  settings:
+    dockerfile: docker/Dockerfile.windows.1803
+    dry_run: true
+    password:
+      from_secret: docker_password
+    repo: plugins/base
+    tags: windows-1803
+    username:
+      from_secret: docker_username
+  volumes:
+  - name: docker_pipe
+    path: //./pipe/docker_engine
+  when:
+    event:
+    - pull_request
+
+- name: publish
+  pull: always
+  image: plugins/docker:windows-1803
+  settings:
+    auto_tag: true
+    auto_tag_suffix: windows-1803
+    dockerfile: docker/Dockerfile.windows.1803
+    password:
+      from_secret: docker_password
+    repo: plugins/base
+    username:
+      from_secret: docker_username
+  volumes:
+  - name: docker_pipe
+    path: //./pipe/docker_engine
+  when:
+    event:
+    - push
+
+volumes:
+- name: docker_pipe
+  host:
+    path: //./pipe/docker_engine
+
+trigger:
+  branch:
+  - master
+
+---
+kind: pipeline
 name: windows-1809
 
 platform:
@@ -20,6 +77,9 @@ steps:
     tags: windows-1809
     username:
       from_secret: docker_username
+  volumes:
+  - name: docker_pipe
+    path: //./pipe/docker_engine
   when:
     event:
     - pull_request
@@ -36,6 +96,52 @@ steps:
     repo: plugins/base
     username:
       from_secret: docker_username
+  volumes:
+  - name: docker_pipe
+    path: //./pipe/docker_engine
+  when:
+    event:
+    - push
+
+volumes:
+- name: docker_pipe
+  host:
+    path: //./pipe/docker_engine
+
+trigger:
+  branch:
+  - master
+
+---
+kind: pipeline
+name: notifications
+
+platform:
+  os: windows
+  arch: amd64
+  version: 1809
+
+steps:
+- name: manifest
+  pull: always
+  image: plugins/manifest:windows-1809
+  settings:
+    ignore_missing: true
+    password:
+      from_secret: docker_password
+    spec: docker/manifest.tmpl
+    username:
+      from_secret: docker_username
+  when:
+    event:
+    - push
+
+- name: microbadger
+  pull: always
+  image: plugins/webhook:windows-1809
+  settings:
+    url:
+      from_secret: microbadger_url
   when:
     event:
     - push
@@ -43,3 +149,9 @@ steps:
 trigger:
   branch:
   - master
+
+depends_on:
+- windows-1803
+- windows-1809
+
+...

--- a/.drone.windows.yml
+++ b/.drone.windows.yml
@@ -124,7 +124,7 @@ platform:
 steps:
 - name: manifest
   pull: always
-  image: plugins/manifest:windows-1809
+  image: plugins/manifest:1
   settings:
     ignore_missing: true
     password:
@@ -138,7 +138,7 @@ steps:
 
 - name: microbadger
   pull: always
-  image: plugins/webhook:windows-1809
+  image: plugins/webhook:1
   settings:
     url:
       from_secret: microbadger_url

--- a/.drone.yml
+++ b/.drone.yml
@@ -190,7 +190,7 @@ platform:
 steps:
 - name: manifest
   pull: always
-  image: plugins/manifest:1
+  image: plugins/manifest:linux-amd64
   settings:
     ignore_missing: true
     password:
@@ -204,7 +204,7 @@ steps:
 
 - name: microbadger
   pull: always
-  image: plugins/webhook:1
+  image: plugins/webhook:linux-amd64
   settings:
     url:
       from_secret: microbadger_url
@@ -215,11 +215,5 @@ steps:
 trigger:
   branch:
   - master
-
-depends_on:
-- linux-amd64
-- linux-arm64
-- linux-arm
-- linux-multiarch
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -190,7 +190,7 @@ platform:
 steps:
 - name: manifest
   pull: always
-  image: plugins/manifest:linux-amd64
+  image: plugins/manifest:1
   settings:
     ignore_missing: true
     password:
@@ -204,7 +204,7 @@ steps:
 
 - name: microbadger
   pull: always
-  image: plugins/webhook:linux-amd64
+  image: plugins/webhook:1
   settings:
     url:
       from_secret: microbadger_url
@@ -215,5 +215,11 @@ steps:
 trigger:
   branch:
   - master
+
+depends_on:
+- linux-amd64
+- linux-arm64
+- linux-arm
+- linux-multiarch
 
 ...

--- a/docker/Dockerfile.windows.1803
+++ b/docker/Dockerfile.windows.1803
@@ -1,0 +1,9 @@
+# escape=`
+FROM mcr.microsoft.com/powershell:nanoserver-1803
+
+LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" `
+  org.label-schema.name="Drone Base" `
+  org.label-schema.vendor="Drone.IO Community" `
+  org.label-schema.schema-version="1.0"
+
+SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/docker/manifest.tmpl
+++ b/docker/manifest.tmpl
@@ -24,6 +24,12 @@ manifests:
       os: linux
       variant: v7
   -
+    image: plugins/base:{{#if build.tag}}{{trimPrefix build.tag "v"}}-{{/if}}windows-1803
+    platform:
+      architecture: amd64
+      os: windows
+      version: 1803
+  -
     image: plugins/base:{{#if build.tag}}{{trimPrefix build.tag "v"}}-{{/if}}windows-1809
     platform:
       architecture: amd64

--- a/pipeline.libsonnet
+++ b/pipeline.libsonnet
@@ -1,0 +1,98 @@
+{
+  build(os='linux', arch='amd64', version='')::
+    local tag = if os == 'windows' then os + '-' + version else os + '-' + arch;
+    local file_suffix = std.strReplace(tag, '-', '.');
+    local volumes = if os == 'windows' then [{ name: 'docker_pipe', path: '//./pipe/docker_engine' }] else [];
+    {
+      kind: 'pipeline',
+      name: tag,
+      platform: {
+        os: os,
+        arch: arch,
+        version: if std.length(version) > 0 then version,
+      },
+      steps: [
+        {
+          name: 'dryrun',
+          image: 'plugins/docker:' + tag,
+          pull: 'always',
+          settings: {
+            dry_run: true,
+            tags: tag,
+            dockerfile: 'docker/Dockerfile.' + file_suffix,
+            repo: 'plugins/base',
+            username: { from_secret: 'docker_username' },
+            password: { from_secret: 'docker_password' },
+          },
+          volumes: if std.length(volumes) > 0 then volumes,
+          when: {
+            event: ['pull_request'],
+          },
+        },
+        {
+          name: 'publish',
+          image: 'plugins/docker:' + tag,
+          pull: 'always',
+          settings: {
+            auto_tag: true,
+            auto_tag_suffix: tag,
+            dockerfile: 'docker/Dockerfile.' + file_suffix,
+            repo: 'plugins/base',
+            username: { from_secret: 'docker_username' },
+            password: { from_secret: 'docker_password' },
+          },
+          volumes: if std.length(volumes) > 0 then volumes,
+          when: {
+            event: ['push'],
+          },
+        },
+      ],
+      trigger: {
+        branch: ['master'],
+      },
+      volumes: if os == 'windows' then [{ name: 'docker_pipe', host: { path: '//./pipe/docker_engine' } }],
+    },
+
+  notifications(os='linux', arch='amd64', version='', depends_on=[])::
+    local tag = if os == 'windows' then os + '-' + version else os + '-' + arch;
+    {
+      kind: 'pipeline',
+      name: 'notifications',
+      platform: {
+        os: os,
+        arch: arch,
+        version: if std.length(version) > 0 then version,
+      },
+      steps: [
+        {
+          name: 'manifest',
+          image: 'plugins/manifest:' + tag,
+          pull: 'always',
+          settings: {
+            username: { from_secret: 'docker_username' },
+            password: { from_secret: 'docker_password' },
+            spec: 'docker/manifest.tmpl',
+            ignore_missing: true,
+          },
+          when: {
+            event: ['push'],
+          },
+        },
+        {
+          name: 'microbadger',
+          image: 'plugins/webhook:' + tag,
+          pull: 'always',
+          settings: {
+            url: { from_secret: 'microbadger_url' },
+          },
+          when: {
+            event: ['push'],
+          },
+        },
+      ],
+      depends_on: depends_on,
+      trigger: {
+        branch: ['master'],
+      },
+    },
+}

--- a/pipeline.libsonnet
+++ b/pipeline.libsonnet
@@ -54,7 +54,6 @@
     },
 
   notifications(os='linux', arch='amd64', version='', depends_on=[])::
-    local tag = if os == 'windows' then os + '-' + version else os + '-' + arch;
     {
       kind: 'pipeline',
       name: 'notifications',
@@ -66,7 +65,7 @@
       steps: [
         {
           name: 'manifest',
-          image: 'plugins/manifest:' + tag,
+          image: 'plugins/manifest:1',
           pull: 'always',
           settings: {
             username: { from_secret: 'docker_username' },
@@ -80,7 +79,7 @@
         },
         {
           name: 'microbadger',
-          image: 'plugins/webhook:' + tag,
+          image: 'plugins/webhook:1',
           pull: 'always',
           settings: {
             url: { from_secret: 'microbadger_url' },


### PR DESCRIPTION
This makes a `pipeline.libsonnet` file which can be used by both the `.drone.jsonnet` and the `.drone.windows.jsonnet` to output the yamls.

Also adds in a 1803 build.