### PR TITLE
Set user to ContainerAdministrator on Windows

### DIFF
--- a/docker/Dockerfile.windows.1809
+++ b/docker/Dockerfile.windows.1809
@@ -1,5 +1,6 @@
 # escape=`
 FROM mcr.microsoft.com/powershell:nanoserver-1809@sha256:e1f802ad42617d536f826538afdd1d4911908ddd6aaa88ad9752b4f180f5da15
+USER ContainerAdministrator
 
 LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" `
   org.label-schema.name="Drone Base" `

--- a/docker/Dockerfile.windows.1903
+++ b/docker/Dockerfile.windows.1903
@@ -1,5 +1,6 @@
 # escape=`
 FROM mcr.microsoft.com/powershell:nanoserver-1903@sha256:75e10cd246ad93636cd183d2f4a4480812c87a91ddb2df2df0bbd45801a04a3d
+USER ContainerAdministrator
 
 LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" `
   org.label-schema.name="Drone Base" `


### PR DESCRIPTION
In Windows Server Core the default user is `ContainerAdministrator` but in Windows Nano Server it is `ContainerUser`. This means that if a plugin tries to access anything that's created by a build step using Windows Server Core that it will be inaccessible.