### PR TITLE
Add Windows 1909 and 2004 base images

### DIFF
--- a/docker/Dockerfile.windows.1909
+++ b/docker/Dockerfile.windows.1909
@@ -1,0 +1,10 @@
+# escape=`
+FROM mcr.microsoft.com/powershell:nanoserver-1909
+USER ContainerAdministrator
+
+LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" `
+  org.label-schema.name="Drone Base" `
+  org.label-schema.vendor="Drone.IO Community" `
+  org.label-schema.schema-version="1.0"
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/docker/Dockerfile.windows.2004
+++ b/docker/Dockerfile.windows.2004
@@ -1,0 +1,10 @@
+# escape=`
+FROM mcr.microsoft.com/powershell:nanoserver-2004
+USER ContainerAdministrator
+
+LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" `
+  org.label-schema.name="Drone Base" `
+  org.label-schema.vendor="Drone.IO Community" `
+  org.label-schema.schema-version="1.0"
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/docker/manifest.tmpl
+++ b/docker/manifest.tmpl
@@ -20,6 +20,11 @@ manifests:
       architecture: arm
       os: linux
       variant: v7
+  - image: plugins/base:{{#if build.tag}}{{trimPrefix build.tag "v"}}-{{/if}}windows-1909-amd64
+    platform:
+      architecture: amd64
+      os: windows
+      version: 1909
   - image: plugins/base:{{#if build.tag}}{{trimPrefix build.tag "v"}}-{{/if}}windows-1903-amd64
     platform:
       architecture: amd64

--- a/docker/manifest.tmpl
+++ b/docker/manifest.tmpl
@@ -20,6 +20,11 @@ manifests:
       architecture: arm
       os: linux
       variant: v7
+  - image: plugins/base:{{#if build.tag}}{{trimPrefix build.tag "v"}}-{{/if}}windows-2004-amd64
+    platform:
+      architecture: amd64
+      os: windows
+      version: 2004
   - image: plugins/base:{{#if build.tag}}{{trimPrefix build.tag "v"}}-{{/if}}windows-1909-amd64
     platform:
       architecture: amd64

--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
   "dockerfile": {
     "fileMatch": [
       "docker/Dockerfile\\.linux\\.(arm|arm64|amd64|multiarch)",
-      "docker/Dockerfile\\.windows\\.(1803|1809|1903)"
+      "docker/Dockerfile\\.windows\\.(1803|1809|1903|1909)"
     ],
     "pinDigests": true
   },

--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
   "dockerfile": {
     "fileMatch": [
       "docker/Dockerfile\\.linux\\.(arm|arm64|amd64|multiarch)",
-      "docker/Dockerfile\\.windows\\.(1803|1809|1903|1909)"
+      "docker/Dockerfile\\.windows\\.(1803|1809|1903|1909|2004)"
     ],
     "pinDigests": true
   },


### PR DESCRIPTION
Add Windows 1909 and 2004 base images to drone-base. Hook them into the manifest as well.