### PR TITLE
Allow renovate to approve and merge PRs

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -2,7 +2,7 @@ repository:
   name: drone-base
   description: Base image used by the plugins
   homepage:
-  topics: drone
+  topics: drone, drone-plugin
 
   private: false
   has_issues: true
@@ -69,7 +69,9 @@ branches:
           - continuous-integration/drone/pr
       enforce_admins: false
       restrictions:
+        apps:
+          - renovate
         users: []
         teams:
           - Admins
-          - Captain
+          - Maintainers

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,11 @@
 {
   "extends": [
-    "config:base"
+    "config:base",
+    ":automergeMinor",
+    ":automergeDigest"
+  ],
+  "enabledManagers": [
+    "dockerfile"
   ],
   "dockerfile": {
     "fileMatch": [


### PR DESCRIPTION
The Windows base images get updated on a fairly regular cadence so just let Renovate approve them so they can be automatically merged.

