### PR TITLE
feat: [CI-23699]: windows 2025 support

### DIFF
--- a/docker/Dockerfile.windows.ltsc2025
+++ b/docker/Dockerfile.windows.ltsc2025
@@ -1,0 +1,44 @@
+# escape=`
+
+# ---------------------------------------------------------------------------
+# drone-base for Windows Server 2025 (LTSC 2025)
+#
+# The ltsc2022 sibling uses mcr.microsoft.com/powershell:nanoserver-ltsc2022 as
+# its single base -- Microsoft ships PowerShell 7 pre-installed there. As of
+# 2026, MCR does not publish any powershell:*-ltsc2025 variant, so we replicate
+# what that base gives us: nanoserver:ltsc2025 with PowerShell 7 installed
+# manually and put on PATH.
+#
+# Downstream plugins (drone-gcs, drone-s3, drone-meltwater-cache, etc.) do
+# `FROM plugins/base:windows-ltsc2025-amd64` and expect PowerShell 7 to be
+# available. That contract is preserved here.
+# ---------------------------------------------------------------------------
+
+# Stage 1: download and extract PowerShell 7 on servercore.
+# servercore ships Windows PowerShell 5.1, which we use to run Invoke-WebRequest
+# and Expand-Archive to fetch the standalone PS7 ZIP release from GitHub.
+FROM mcr.microsoft.com/windows/servercore:ltsc2025 AS installer-env
+SHELL ["C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe", "-Command"]
+RUN $ProgressPreference = 'SilentlyContinue'; `
+    [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12; `
+    Invoke-WebRequest -Uri "https://github.com/PowerShell/PowerShell/releases/download/v7.4.6/PowerShell-7.4.6-win-x64.zip" -OutFile C:\powershell.zip -UseBasicParsing; `
+    Expand-Archive C:\powershell.zip -DestinationPath C:\PowerShell
+
+# Stage 2: final nanoserver image with PowerShell 7 copied in.
+FROM mcr.microsoft.com/windows/nanoserver:ltsc2025
+USER ContainerAdministrator
+
+LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" `
+  org.label-schema.name="Drone Base" `
+  org.label-schema.vendor="Drone.IO Community" `
+  org.label-schema.schema-version="1.0"
+
+ENV POWERSHELL_DISTRIBUTION_CHANNEL="PSDocker-NanoServer-ltsc2025" `
+    POWERSHELL_TELEMETRY_OPTOUT="1"
+
+COPY --from=installer-env C:\PowerShell C:\PowerShell
+
+
+ENV PATH="C:\\PowerShell;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\WindowsPowerShell\\v1.0"
+
+SHELL ["pwsh.exe", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/docker/manifest.tmpl
+++ b/docker/manifest.tmpl
@@ -25,3 +25,8 @@ manifests:
       architecture: amd64
       os: windows
       version: ltsc2022
+  - image: plugins/base:{{#if build.tag}}{{trimPrefix build.tag "v"}}-{{/if}}windows-ltsc2025-amd64
+    platform:
+      architecture: amd64
+      os: windows
+      version: ltsc2025


### PR DESCRIPTION
This pull request adds support for Windows Server 2025 (LTSC 2025) to the Drone base images. The main focus is to ensure that downstream plugins can use a Windows LTSC 2025 base image with PowerShell 7 available, maintaining compatibility and consistency with previous LTSC releases.

**Windows LTSC 2025 base image support:**

* Added a new `Dockerfile.windows.ltsc2025` that builds a Windows NanoServer LTSC 2025 image with PowerShell 7.4.6 manually installed and added to the `PATH`, preserving the expected environment for downstream plugins.
* Updated `docker/manifest.tmpl` to include the new `plugins/base:windows-ltsc2025-amd64` image for LTSC 2025, so it is published alongside other supported platforms.